### PR TITLE
Add submit book pick up endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,24 @@ And then run your app using the java command:
 java -jar <path>book-pickup-service-0.0.1-SNAPSHOT.jar 
 ```
 
+### Endpoint List
+
+* Get list of books by subject
+```
+curl --location 'http://localhost:8080/api/v1/books/book-list?subject=java'
+```
+
+* Submit a book pick up schedule 
+```
+curl --location 'http://localhost:8080/api/v1/books/pickup' \
+--header 'Content-Type: application/json' \
+--data '{
+    "edition_numbers": 26,
+    "pick_up_date_time" : "2023-06-10 10:08:02",
+    "username" : "rully",
+    "phone_number" : "081224816942"
+}'
+```
 ### Version
 
 * 0.0.1

--- a/pom.xml
+++ b/pom.xml
@@ -26,6 +26,17 @@
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-cache</artifactId>
 		</dependency>
+		<!-- validation -->
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-validation</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>javax.validation</groupId>
+			<artifactId>validation-api</artifactId>
+			<version>2.0.1.Final</version>
+		</dependency>
+		<!-- utils -->
 		<dependency>
 			<groupId>org.projectlombok</groupId>
 			<artifactId>lombok</artifactId>
@@ -36,6 +47,7 @@
 			<artifactId>commons-lang3</artifactId>
 			<version>3.12.0</version>
 		</dependency>
+		<!-- client -->
 		<dependency>
 			<groupId>commons-io</groupId>
 			<artifactId>commons-io</artifactId>

--- a/src/main/java/com/online/demo/bookpickupservice/constant/BooksConstant.java
+++ b/src/main/java/com/online/demo/bookpickupservice/constant/BooksConstant.java
@@ -7,5 +7,6 @@ import lombok.NoArgsConstructor;
 public class BooksConstant {
 
     public static final String API_BOOK_LIST = "book-list";
+    public static final String API_BOOK_PICK_UP = "pickup";
 
 }

--- a/src/main/java/com/online/demo/bookpickupservice/controller/BooksController.java
+++ b/src/main/java/com/online/demo/bookpickupservice/controller/BooksController.java
@@ -2,17 +2,18 @@ package com.online.demo.bookpickupservice.controller;
 
 import com.online.demo.bookpickupservice.constant.BooksConstant;
 import com.online.demo.bookpickupservice.dto.BooksDTO;
+import com.online.demo.bookpickupservice.dto.SubmitBookRequest;
+import com.online.demo.bookpickupservice.dto.SubmitBookResponse;
 import com.online.demo.bookpickupservice.service.BookService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
+import javax.validation.Valid;
 import java.util.List;
+import java.util.Objects;
 
 @RestController
 @RequestMapping("/api/v1/books/")
@@ -30,6 +31,21 @@ public class BooksController {
             return ResponseEntity.notFound().build();
         }
         return ResponseEntity.ok(bookService.getBooksBySubject(subject));
+    }
+
+    @PostMapping(value = BooksConstant.API_BOOK_PICK_UP, produces = MediaType.APPLICATION_JSON_VALUE)
+    public ResponseEntity<Object> submitBookPickUp(@Valid @RequestBody SubmitBookRequest submitBookRequest){
+        try {
+            log.info("Request " + BooksConstant.API_BOOK_PICK_UP + " with payload : " + submitBookRequest);
+            SubmitBookResponse submitBookResponse = bookService.submitBookPickup(submitBookRequest);
+            if (Objects.isNull(submitBookResponse)){
+                return ResponseEntity.badRequest().build();
+            }
+            return ResponseEntity.ok(submitBookResponse);
+        } catch (Exception e) {
+            log.error(String.format("Error when submit book pickup: %s", submitBookRequest), e);
+            return ResponseEntity.internalServerError().build();
+        }
     }
 
 }

--- a/src/main/java/com/online/demo/bookpickupservice/controller/BooksController.java
+++ b/src/main/java/com/online/demo/bookpickupservice/controller/BooksController.java
@@ -4,6 +4,7 @@ import com.online.demo.bookpickupservice.constant.BooksConstant;
 import com.online.demo.bookpickupservice.dto.BooksDTO;
 import com.online.demo.bookpickupservice.dto.SubmitBookRequest;
 import com.online.demo.bookpickupservice.dto.SubmitBookResponse;
+import com.online.demo.bookpickupservice.enumeration.SubmitResponseEnum;
 import com.online.demo.bookpickupservice.service.BookService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -40,6 +41,9 @@ public class BooksController {
             SubmitBookResponse submitBookResponse = bookService.submitBookPickup(submitBookRequest);
             if (Objects.isNull(submitBookResponse)){
                 return ResponseEntity.badRequest().build();
+            }
+            if (submitBookResponse.getStatus().contentEquals(SubmitResponseEnum.FAILED.name())){
+                return ResponseEntity.notFound().build();
             }
             return ResponseEntity.ok(submitBookResponse);
         } catch (Exception e) {

--- a/src/main/java/com/online/demo/bookpickupservice/dto/SubmitBookRequest.java
+++ b/src/main/java/com/online/demo/bookpickupservice/dto/SubmitBookRequest.java
@@ -1,0 +1,34 @@
+package com.online.demo.bookpickupservice.dto;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
+import java.time.LocalDateTime;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+@Builder
+public class SubmitBookRequest {
+
+    @NotNull
+    private Integer editionNumbers;
+    @JsonFormat(pattern="yyyy-MM-dd HH:mm:ss")
+    private LocalDateTime pickUpDateTime;
+    @NotBlank
+    private String username;
+    private String phoneNumber;
+
+}

--- a/src/main/java/com/online/demo/bookpickupservice/dto/SubmitBookResponse.java
+++ b/src/main/java/com/online/demo/bookpickupservice/dto/SubmitBookResponse.java
@@ -6,21 +6,19 @@ import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.*;
 
-import java.util.List;
+import java.time.LocalDateTime;
 
 @Data
+@Builder
 @JsonIgnoreProperties(ignoreUnknown = true)
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
-@NoArgsConstructor
-@AllArgsConstructor
-@Builder
-public class BooksDTO {
+@ToString
+public class SubmitBookResponse {
 
-    private Integer editionNumbers;
-    private String title;
-    private List<String> authors;
     private String status;
-    private Boolean availableToBorrow;
+    private BooksDTO book;
+    private String username;
+    private LocalDateTime pickUpDateTime;
 
 }

--- a/src/main/java/com/online/demo/bookpickupservice/enumeration/SubmitResponseEnum.java
+++ b/src/main/java/com/online/demo/bookpickupservice/enumeration/SubmitResponseEnum.java
@@ -5,6 +5,6 @@ import lombok.Getter;
 @Getter
 public enum SubmitResponseEnum {
 
-    SUCCESS, FAILED;
+    SUCCESS, FAILED
 
 }

--- a/src/main/java/com/online/demo/bookpickupservice/enumeration/SubmitResponseEnum.java
+++ b/src/main/java/com/online/demo/bookpickupservice/enumeration/SubmitResponseEnum.java
@@ -1,0 +1,10 @@
+package com.online.demo.bookpickupservice.enumeration;
+
+import lombok.Getter;
+
+@Getter
+public enum SubmitResponseEnum {
+
+    SUCCESS, FAILED;
+
+}

--- a/src/main/java/com/online/demo/bookpickupservice/model/BookDatabase.java
+++ b/src/main/java/com/online/demo/bookpickupservice/model/BookDatabase.java
@@ -1,0 +1,45 @@
+package com.online.demo.bookpickupservice.model;
+
+import com.online.demo.bookpickupservice.dto.BooksDTO;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class BookDatabase {
+
+    private static BookDatabase instance;
+    private final Map<Integer, BooksDTO> database;
+
+    private BookDatabase() {
+        database = new HashMap<>();
+    }
+
+    public static synchronized BookDatabase getInstance() {
+        if (instance == null) {
+            instance = new BookDatabase();
+        }
+        return instance;
+    }
+
+    public void reset() {
+        database.clear();
+    }
+
+    public void update(List<BooksDTO> response) {
+        if (response == null ) {
+            return;
+        }
+
+        for (BooksDTO booksDTO : response) {
+            if (booksDTO.getEditionNumbers() != null) {
+                database.put(booksDTO.getEditionNumbers(), booksDTO);
+            }
+        }
+    }
+
+    public BooksDTO getByEditionNumber(Integer editionNumber) {
+        return database.get(editionNumber);
+    }
+
+}

--- a/src/main/java/com/online/demo/bookpickupservice/model/BookDatabase.java
+++ b/src/main/java/com/online/demo/bookpickupservice/model/BookDatabase.java
@@ -6,20 +6,14 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-public class BookDatabase {
+public enum BookDatabase {
 
-    private static BookDatabase instance;
+    INSTANCE;
+
     private final Map<Integer, BooksDTO> database;
 
-    private BookDatabase() {
+    BookDatabase() {
         database = new HashMap<>();
-    }
-
-    public static synchronized BookDatabase getInstance() {
-        if (instance == null) {
-            instance = new BookDatabase();
-        }
-        return instance;
     }
 
     public void reset() {
@@ -27,7 +21,7 @@ public class BookDatabase {
     }
 
     public void update(List<BooksDTO> response) {
-        if (response == null ) {
+        if (response == null) {
             return;
         }
 

--- a/src/main/java/com/online/demo/bookpickupservice/service/BookService.java
+++ b/src/main/java/com/online/demo/bookpickupservice/service/BookService.java
@@ -1,11 +1,15 @@
 package com.online.demo.bookpickupservice.service;
 
 import com.online.demo.bookpickupservice.dto.BooksDTO;
+import com.online.demo.bookpickupservice.dto.SubmitBookRequest;
+import com.online.demo.bookpickupservice.dto.SubmitBookResponse;
 
 import java.util.List;
 
 public interface BookService {
 
     List<BooksDTO> getBooksBySubject(String subject);
+
+    SubmitBookResponse submitBookPickup(SubmitBookRequest submitBookRequest);
 
 }

--- a/src/main/java/com/online/demo/bookpickupservice/service/BookServiceImpl.java
+++ b/src/main/java/com/online/demo/bookpickupservice/service/BookServiceImpl.java
@@ -34,7 +34,7 @@ public class BookServiceImpl implements BookService{
         }
 
         List<BooksDTO> booksDTOList = new ArrayList<>();
-        BookDatabase bookDatabase = BookDatabase.getInstance();
+        BookDatabase bookDatabase = BookDatabase.INSTANCE;
         for (SubjectsAPIResponse.Works work : subjectsAPIResponse.getWorks()) {
             List<String> authorNames = extractAuthorNames(work.getAuthors());
             BooksDTO booksDTO = BooksDTO.builder()
@@ -56,14 +56,14 @@ public class BookServiceImpl implements BookService{
     @Override
     public SubmitBookResponse submitBookPickup(SubmitBookRequest submitBookRequest) {
         log.info("Get data from memory ");
-        BookDatabase database = BookDatabase.getInstance();
+        BookDatabase database = BookDatabase.INSTANCE;
         BooksDTO booksDTO = database.getByEditionNumber(submitBookRequest.getEditionNumbers());
         log.info("Result -> {}", booksDTO);
         if (booksDTO == null){
             log.error("Data not found or empty !");
             return buildFailedResponse();
         }
-        if (!booksDTO.getAvailableToBorrow()){
+        if (Boolean.FALSE.equals(booksDTO.getAvailableToBorrow())){
             log.error("Unable to borrow the book!");
             return buildFailedResponse();
         }

--- a/src/main/java/com/online/demo/bookpickupservice/service/BookServiceImpl.java
+++ b/src/main/java/com/online/demo/bookpickupservice/service/BookServiceImpl.java
@@ -3,6 +3,10 @@ package com.online.demo.bookpickupservice.service;
 import com.online.demo.bookpickupservice.client.OpenLibraryClient;
 import com.online.demo.bookpickupservice.dto.BooksDTO;
 import com.online.demo.bookpickupservice.dto.SubjectsAPIResponse;
+import com.online.demo.bookpickupservice.dto.SubmitBookRequest;
+import com.online.demo.bookpickupservice.dto.SubmitBookResponse;
+import com.online.demo.bookpickupservice.enumeration.SubmitResponseEnum;
+import com.online.demo.bookpickupservice.model.BookDatabase;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.cache.annotation.Cacheable;
@@ -30,6 +34,7 @@ public class BookServiceImpl implements BookService{
         }
 
         List<BooksDTO> booksDTOList = new ArrayList<>();
+        BookDatabase bookDatabase = BookDatabase.getInstance();
         for (SubjectsAPIResponse.Works work : subjectsAPIResponse.getWorks()) {
             List<String> authorNames = extractAuthorNames(work.getAuthors());
             BooksDTO booksDTO = BooksDTO.builder()
@@ -37,14 +42,32 @@ public class BookServiceImpl implements BookService{
                     .authors(authorNames)
                     .build();
             if (work.getAvailability() != null) {
-                booksDTO.setEditionNumbers(work.getAvailability().getIsbn());
+                booksDTO.setEditionNumbers(work.getEditionCount());
                 booksDTO.setStatus(work.getAvailability().getStatus());
                 booksDTO.setAvailableToBorrow(work.getAvailability().getAvailableToBorrow());
             }
             booksDTOList.add(booksDTO);
         }
+        bookDatabase.update(booksDTOList);
 
         return booksDTOList;
+    }
+
+    @Override
+    public SubmitBookResponse submitBookPickup(SubmitBookRequest submitBookRequest) {
+        log.info("Get data from memory ");
+        BookDatabase database = BookDatabase.getInstance();
+        BooksDTO booksDTO = database.getByEditionNumber(submitBookRequest.getEditionNumbers());
+        log.info("Result -> {}", booksDTO);
+        if (booksDTO == null){
+            log.error("Data not found or empty !");
+            return buildFailedResponse();
+        }
+        if (!booksDTO.getAvailableToBorrow()){
+            log.error("Unable to borrow the book!");
+            return buildFailedResponse();
+        }
+       return buildSuccessResponse(booksDTO, submitBookRequest);
     }
 
     private List<String> extractAuthorNames(List<SubjectsAPIResponse.Works.Authors> authors) {
@@ -54,5 +77,20 @@ public class BookServiceImpl implements BookService{
         return authors.stream()
                 .map(SubjectsAPIResponse.Works.Authors::getName)
                 .collect(Collectors.toList());
+    }
+
+    private SubmitBookResponse buildSuccessResponse(BooksDTO booksDTO, SubmitBookRequest submitBookRequest){
+        return SubmitBookResponse.builder()
+                .status(SubmitResponseEnum.SUCCESS.toString())
+                .book(booksDTO)
+                .username(submitBookRequest.getUsername())
+                .pickUpDateTime(submitBookRequest.getPickUpDateTime())
+                .build();
+    }
+
+    private SubmitBookResponse buildFailedResponse(){
+        return SubmitBookResponse.builder()
+                .status(SubmitResponseEnum.FAILED.toString())
+                .build();
     }
 }

--- a/src/test/java/com/online/demo/bookpickupservice/controller/BooksControllerTest.java
+++ b/src/test/java/com/online/demo/bookpickupservice/controller/BooksControllerTest.java
@@ -1,7 +1,11 @@
 package com.online.demo.bookpickupservice.controller;
 
 import com.online.demo.bookpickupservice.dto.BooksDTO;
+import com.online.demo.bookpickupservice.dto.SubmitBookRequest;
+import com.online.demo.bookpickupservice.dto.SubmitBookResponse;
+import com.online.demo.bookpickupservice.enumeration.SubmitResponseEnum;
 import com.online.demo.bookpickupservice.service.BookService;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -11,6 +15,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 
+import java.time.LocalDateTime;
 import java.util.Collections;
 import java.util.List;
 
@@ -57,5 +62,53 @@ class BooksControllerTest {
 
         ResponseEntity<?> result = booksController.getListofBooks(subject);
         assertEquals(HttpStatus.NOT_FOUND, result.getStatusCode());
+    }
+
+    @Test
+    void testSubmitBookPickUp_Success(){
+        SubmitBookRequest submitBookRequest = SubmitBookRequest.builder()
+                .editionNumbers(26)
+                .pickUpDateTime(LocalDateTime.of(2023, 6, 10, 10, 0, 0))
+                .phoneNumber("081122334456")
+                .username("Joni")
+                .build();
+        BooksDTO mockBookDTO = BooksDTO.builder()
+                .availableToBorrow(true)
+                .authors(List.of("Ramsey"))
+                .title("Head First Design Pattern")
+                .build();
+
+        Mockito.when(bookService.submitBookPickup(submitBookRequest)).thenReturn(SubmitBookResponse.builder()
+                        .status(SubmitResponseEnum.SUCCESS.toString())
+                        .book(mockBookDTO)
+                        .username("Joni")
+                        .pickUpDateTime(LocalDateTime.of(2023, 6, 10, 10, 0, 0))
+                .build());
+
+        SubmitBookResponse expectedResponse = SubmitBookResponse.builder()
+                .status(SubmitResponseEnum.SUCCESS.toString())
+                .book(mockBookDTO)
+                .username("Joni")
+                .pickUpDateTime(LocalDateTime.of(2023, 6, 10, 10, 0, 0))
+                .build();
+
+        ResponseEntity<?> result = booksController.submitBookPickUp(submitBookRequest);
+
+        Assertions.assertEquals(expectedResponse, result.getBody());
+    }
+
+    @Test
+    void testSubmitBookPickUp_Failed1(){
+        SubmitBookRequest submitBookRequest = SubmitBookRequest.builder()
+                .editionNumbers(26)
+                .pickUpDateTime(LocalDateTime.of(2023, 6, 10, 10, 0, 0))
+                .phoneNumber("081122334456")
+                .username("Joni")
+                .build();
+        Mockito.when(bookService.submitBookPickup(submitBookRequest)).thenReturn(SubmitBookResponse.builder()
+                        .status(SubmitResponseEnum.FAILED.name())
+                        .build());
+        ResponseEntity<?> result = booksController.submitBookPickUp(submitBookRequest);
+        Assertions.assertEquals(HttpStatus.NOT_FOUND, result.getStatusCode());
     }
 }

--- a/src/test/java/com/online/demo/bookpickupservice/controller/BooksControllerTest.java
+++ b/src/test/java/com/online/demo/bookpickupservice/controller/BooksControllerTest.java
@@ -30,7 +30,7 @@ class BooksControllerTest {
         String subject = "java";
         List<BooksDTO> mockResult = List.of(BooksDTO.builder()
                 .title("Java software solutions")
-                .editionNumbers("0201725975")
+                .editionNumbers(26)
                 .authors(List.of("Lewis, John"))
                 .status("borrow_available")
                 .availableToBorrow(true)
@@ -40,7 +40,7 @@ class BooksControllerTest {
         ResponseEntity<?> result = booksController.getListofBooks(subject);
         List<BooksDTO> expectedResult = List.of(BooksDTO.builder()
                         .title("Java software solutions")
-                        .editionNumbers("0201725975")
+                        .editionNumbers(26)
                         .authors(List.of("Lewis, John"))
                         .status("borrow_available")
                         .availableToBorrow(true)

--- a/src/test/java/com/online/demo/bookpickupservice/service/BookServiceTest.java
+++ b/src/test/java/com/online/demo/bookpickupservice/service/BookServiceTest.java
@@ -30,13 +30,13 @@ class BookServiceTest {
         SubjectsAPIResponse.Works works = SubjectsAPIResponse.Works.builder()
                 .key("/works/OL94732W")
                 .title(title)
+                .editionCount(26)
                 .authors(List.of(SubjectsAPIResponse.Works.Authors.builder()
                                 .name("Lewis, John")
                                 .build()))
                 .availability(SubjectsAPIResponse.Works.Availability.builder()
                         .availableToBorrow(true)
                         .status("borrow_available")
-                        .isbn("0201725975")
                         .build())
                 .build();
         SubjectsAPIResponse mockApiResponse = SubjectsAPIResponse.builder()
@@ -48,7 +48,7 @@ class BookServiceTest {
         List<BooksDTO> result = bookService.getBooksBySubject(subject);
 
         List<BooksDTO> expected = List.of(BooksDTO.builder()
-                        .editionNumbers("0201725975")
+                        .editionNumbers(26)
                         .title(title)
                         .authors(List.of("Lewis, John"))
                         .status("borrow_available")


### PR DESCRIPTION
Add submit book pick-up endpoint.

- Add request validation
- Store data in memory when getting a list of books
- Get data by`editionNumbers` key
- Check `availableToBorrow` as validation when pick-up a book
